### PR TITLE
Update JSONLD module to use new HAL link_manager service

### DIFF
--- a/jsonld.info.yml
+++ b/jsonld.info.yml
@@ -4,6 +4,6 @@ description: 'Serializes entities to JSON-LD / LDP for the islandora CLAW Projec
 package: Web services
 core: 8.x
 dependencies:
-  - rest
+  - hal
   - serialization
   - rdf

--- a/jsonld.services.yml
+++ b/jsonld.services.yml
@@ -1,7 +1,7 @@
 services:
   serializer.normalizer.entity_reference_item.jsonld:
     class: Drupal\jsonld\Normalizer\EntityReferenceItemNormalizer
-    arguments: ['@rest.link_manager', '@serializer.entity_resolver']
+    arguments: ['@hal.link_manager', '@serializer.entity_resolver']
     tags:
       - { name: normalizer, priority: 10 }
   serializer.normalizer.field_item.jsonld:
@@ -16,10 +16,10 @@ services:
     class: Drupal\jsonld\Normalizer\FileEntityNormalizer
     tags:
       - { name: normalizer, priority: 20 }
-    arguments: ['@entity.manager', '@http_client', '@rest.link_manager', '@module_handler']
+    arguments: ['@entity.manager', '@http_client', '@hal.link_manager', '@module_handler']
   serializer.normalizer.entity.jsonld:
     class: Drupal\jsonld\Normalizer\ContentEntityNormalizer
-    arguments: ['@rest.link_manager', '@entity.manager', '@module_handler']
+    arguments: ['@hal.link_manager', '@entity.manager', '@module_handler']
     tags:
       - { name: normalizer, priority: 10 }
   serializer.encoder.jsonld:

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -5,7 +5,7 @@ namespace Drupal\jsonld\Normalizer;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\rest\LinkManager\LinkManagerInterface;
+use Drupal\hal\LinkManager\LinkManagerInterface;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 
 /**
@@ -23,7 +23,7 @@ class ContentEntityNormalizer extends NormalizerBase {
   /**
    * The hypermedia link manager.
    *
-   * @var \Drupal\rest\LinkManager\LinkManagerInterface
+   * @var \Drupal\hal\LinkManager\LinkManagerInterface
    */
   protected $linkManager;
 
@@ -44,7 +44,7 @@ class ContentEntityNormalizer extends NormalizerBase {
   /**
    * Constructs an ContentEntityNormalizer object.
    *
-   * @param \Drupal\rest\LinkManager\LinkManagerInterface $link_manager
+   * @param \Drupal\hal\LinkManager\LinkManagerInterface $link_manager
    *   The hypermedia link manager.
    * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
    *   The entity manager.

--- a/src/Normalizer/EntityReferenceItemNormalizer.php
+++ b/src/Normalizer/EntityReferenceItemNormalizer.php
@@ -3,7 +3,7 @@
 namespace Drupal\jsonld\Normalizer;
 
 use Drupal\Core\Entity\FieldableEntityInterface;
-use Drupal\rest\LinkManager\LinkManagerInterface;
+use Drupal\hal\LinkManager\LinkManagerInterface;
 use Drupal\serialization\EntityResolver\EntityResolverInterface;
 use Drupal\serialization\EntityResolver\UuidReferenceInterface;
 
@@ -22,7 +22,7 @@ class EntityReferenceItemNormalizer extends FieldItemNormalizer implements UuidR
   /**
    * The hypermedia link manager.
    *
-   * @var \Drupal\rest\LinkManager\LinkManagerInterface
+   * @var \Drupal\hal\LinkManager\LinkManagerInterface
    */
   protected $linkManager;
 
@@ -36,9 +36,9 @@ class EntityReferenceItemNormalizer extends FieldItemNormalizer implements UuidR
   /**
    * Constructs an EntityReferenceItemNormalizer object.
    *
-   * @param \Drupal\rest\LinkManager\LinkManagerInterface $link_manager
+   * @param \Drupal\hal\LinkManager\LinkManagerInterface $link_manager
    *   The hypermedia link manager.
-   * @param \Drupal\serialization\EntityResolver\EntityResolverInterface $entity_Resolver
+   * @param \Drupal\hal\EntityResolver\EntityResolverInterface $entity_Resolver
    *   The entity resolver.
    */
   public function __construct(LinkManagerInterface $link_manager, EntityResolverInterface $entity_Resolver) {

--- a/src/Normalizer/FileEntityNormalizer.php
+++ b/src/Normalizer/FileEntityNormalizer.php
@@ -4,7 +4,7 @@ namespace Drupal\jsonld\Normalizer;
 
 use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\rest\LinkManager\LinkManagerInterface;
+use Drupal\hal\LinkManager\LinkManagerInterface;
 use GuzzleHttp\ClientInterface;
 
 /**
@@ -33,7 +33,7 @@ class FileEntityNormalizer extends ContentEntityNormalizer {
    *   The entity manager.
    * @param \GuzzleHttp\ClientInterface $http_client
    *   The HTTP Client.
-   * @param \Drupal\rest\LinkManager\LinkManagerInterface $link_manager
+   * @param \Drupal\hal\LinkManager\LinkManagerInterface $link_manager
    *   The hypermedia link manager.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -12,9 +12,9 @@ use Drupal\jsonld\Normalizer\EntityReferenceItemNormalizer;
 use Drupal\jsonld\Normalizer\FieldItemNormalizer;
 use Drupal\jsonld\Normalizer\FieldNormalizer;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\rest\LinkManager\LinkManager;
-use Drupal\rest\LinkManager\RelationLinkManager;
-use Drupal\rest\LinkManager\TypeLinkManager;
+use Drupal\hal\LinkManager\LinkManager;
+use Drupal\hal\LinkManager\RelationLinkManager;
+use Drupal\hal\LinkManager\TypeLinkManager;
 use Drupal\serialization\EntityResolver\ChainEntityResolver;
 use Drupal\serialization\EntityResolver\TargetIdResolver;
 use Drupal\serialization\EntityResolver\UuidResolver;
@@ -33,7 +33,7 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
     'user',
     'field',
     'filter',
-    'rest',
+    'hal',
     'serialization',
     'rdf',
     'rdf_test_namespaces',


### PR DESCRIPTION
## GitHub Issue

Part of: 
https://github.com/Islandora-CLAW/CLAW/issues/594

Blocked by:
https://github.com/Islandora-CLAW/islandora/pull/56

## What does this Pull Request do?

As per these tickets:
https://www.drupal.org/node/2758897
https://www.drupal.org/node/2854830

The service `rest.link_manager` has been moved into the HAL module. This means JSONLD needs to depend on the HAL module, and some class names etc need to be updated, as well at the wiring for our service. This should let the JSONLD module run on D8.3. This also likely breaks the service for D8.2, as the new dependancy does not exist there.

## How should this be tested?

- Uninstall jsonld, islandora, islandora_collection
- composer require drupal/rules:3.x-dev
- composer require drupal/drupal:8.3.*
- check out this PR for `jsonld`
- drush en islandora

Islandora should enable fine, and should be able to add content etc.

# Interested parties
@Islandora-CLAW/committers