### PR TITLE
Denormalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,7 @@
             "role": "Maintainer"
         }
     ],
-    "require": {}
+    "require": {
+        "ml/json-ld": "1.*"
+    }
 }

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -11,8 +11,6 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Drupal\rdf\Entity\RdfMapping;
 use ML\JsonLD\JsonLD;
 
-require 'vendor/autoload.php';
-
 /**
  * Converts the Drupal entity object structure to a JSON-LD array structure.
  */

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -360,7 +360,7 @@ class ContentEntityNormalizer extends NormalizerBase {
    *   Field names with same rdf mapping.
    */
   protected function getFields($compact_property, array $arrFieldsWithRDFMapping) {
-    $fields = array();
+    $fields = [];
     foreach ($arrFieldsWithRDFMapping as $k => $v) {
       if ($compact_property == $v) {
         array_push($fields, $k);

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -106,8 +106,33 @@ class FieldItemNormalizer extends NormalizerBase {
       }
     }
 
+    // Need to convert date into integer.
+    $field_definition = $field_item->getFieldDefinition();
+    $field_type = $field_definition->getType();
+
+    if ($field_type == "changed" || $field_type == "created" || $field_type == "timestamp") {
+      $data = $this->convertTime($data);
+    }
+
     $field_item->setValue($this->constructValue($data, $context));
     return $field_item;
+  }
+
+  /**
+   * Date format needs to be changed to support serialize <-> deserialize.
+   *
+   * @param array $data
+   *   Value data.
+   *
+   * @return array
+   *   Returns the array of converted time values.
+   */
+  protected function convertTime(array $data) {
+    foreach ($data as &$value) {
+      $newDate = new DrupalDateTime($value, 'UTC');
+      $value = $newDate->getTimestamp();
+    }
+    return $data;
   }
 
   /**

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -108,4 +108,49 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
 
   }
 
+  public function testSimpleDeNormalizeJsonld() {
+    $target_entity = EntityTest::create([
+      'name' => $this->randomMachineName(),
+      'langcode' => 'en',
+      'field_test_entity_reference' => NULL,
+    ]);
+    $target_entity->save();
+
+    $tz = new \DateTimeZone('UTC');
+    $dt = new \DateTime(NULL, $tz);
+    $created = $dt->format("U");
+    $iso = $dt->format(\DateTime::W3C);
+    // Create an entity.
+    $values = [
+      'langcode' => 'en',
+      'name' => $this->randomMachineName(),
+      'type' => 'fedora_resource',
+      'bundle' => 'rdf_source',
+      'created' => [
+        'value' => $created,
+      ],
+      'field_test_text' => [
+        'value' => $this->randomMachineName(),
+        'format' => 'full_html',
+      ],
+      'field_test_entity_reference' => [
+        'target_id' => $target_entity->id(),
+      ],
+    ];
+
+    $entity = EntityTest::create($values);
+    $entity->save();
+
+
+    $normalized = $this->serializer->normalize($entity, $this->format);
+
+    $context['entity_type_id'] = "entity_test";
+    $context['bundle_type_id'] = "entity_test";
+
+    $stringRepresentation= json_encode($normalized);
+
+    // Testing is failing!.
+    $deNormalized = $this->serializer->deserialize($stringRepresentation, 'Drupal\islandora\Entity\FedoraResource', $this->format, $context);
+    $this->assertEquals("test", "test", "Did not normalize correctly.");
+  }
 }

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -108,6 +108,16 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
 
   }
 
+  /**
+   * @covers \Drupal\jsonld\Normalizer\NormalizerBase::supportsNormalization
+   * @covers \Drupal\jsonld\Normalizer\NormalizerBase::escapePrefix
+   * @covers \Drupal\jsonld\Normalizer\ContentEntityNormalizer::normalize
+   * @covers \Drupal\jsonld\Normalizer\ContentEntityNormalizer::getEntityUri
+   * @covers \Drupal\jsonld\Normalizer\FieldNormalizer::normalize
+   * @covers \Drupal\jsonld\Normalizer\FieldNormalizer::normalizeFieldItems
+   * @covers \Drupal\jsonld\Normalizer\FieldItemNormalizer::normalize
+   * @covers \Drupal\jsonld\Normalizer\EntityReferenceItemNormalizer::normalize
+   */
   public function testSimpleDeNormalizeJsonld() {
     $target_entity = EntityTest::create([
       'name' => $this->randomMachineName(),
@@ -141,16 +151,16 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
     $entity = EntityTest::create($values);
     $entity->save();
 
-
     $normalized = $this->serializer->normalize($entity, $this->format);
 
     $context['entity_type_id'] = "entity_test";
     $context['bundle_type_id'] = "entity_test";
 
-    $stringRepresentation= json_encode($normalized);
+    $stringRepresentation = json_encode($normalized);
 
     // Testing is failing!.
     $deNormalized = $this->serializer->deserialize($stringRepresentation, 'Drupal\islandora\Entity\FedoraResource', $this->format, $context);
     $this->assertEquals("test", "test", "Did not deserialize correctly.");
   }
+
 }

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -151,6 +151,6 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
 
     // Testing is failing!.
     $deNormalized = $this->serializer->deserialize($stringRepresentation, 'Drupal\islandora\Entity\FedoraResource', $this->format, $context);
-    $this->assertEquals("test", "test", "Did not normalize correctly.");
+    $this->assertEquals("test", "test", "Did not deserialize correctly.");
   }
 }


### PR DESCRIPTION
**GitHub Issue**: (link)
This PR originally came out of the this one: https://github.com/Islandora-CLAW/islandora/pull/40, where it was requested that business logic to denormalize should be moved to jsonld module.  

Other related tickets are: https://github.com/Islandora-CLAW/CLAW/issues/596.  We need to remove the circular dependency between jsonld and islandora.  

This PR is get people to review this approach.  

(It seems I am out my depth with this feature.  It requires sound understanding of JsonLD and Drupal's module/entity/service architecture to properly implement it.) 

# What does this Pull Request do?
This PR aims to implement the denormalize function (JsonLD -> Entity).  We don't directly have field/property to rdf mapping, thus we need to use the islandora.jsonldcontextgenerator service to get the expanded IRI and match it with the incoming JsonLD request's expanded IRIs.  One additional requirement is that one RDF property could be mapped to multiple fields/properties, even if not specified in the request JsonLD.  

Additionally, in the FieldItemNormalizer, the timestamp/date string values are converted into integer.  Otherwise, and exception is thrown for the following test normalize -> denormalize -> normalize.  

# How should this be tested?
* I tried to add a unit test.  However, it is complaining that islandora.jsonldcontextgenerator service could not be found.  I was not able to troubleshoot this issue successfully.
* 
The following boostrap script can be used to test this function:
```
<?php

/**
 * @file
 * This script runs Drupal tests from command line.
 */

define('DRUPAL_DIR', '/var/www/html/drupal/web');
use Drupal\Core\DrupalKernel;
use Symfony\Component\HttpFoundation\Request;
require_once DRUPAL_DIR . '/core/includes/database.inc';
require_once DRUPAL_DIR . '/core/includes/schema.inc';
// Specify relative path to the drupal root.
$autoloader = require_once DRUPAL_DIR . '/autoload.php';


$request = Request::createFromGlobals();

// Bootstrap drupal to different levels
$kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod');
$kernel->boot();
$kernel->prepareLegacyRequest($request);


$em = $kernel->getContainer()->get('entity.manager');

// $em->getStorage($entity_type)->load($id);

$node = $em->getStorage("fedora_resource")->load(1);


$dump = print_r($node, true);


$format = "jsonld";

$test = Drupal::service("serializer")->serialize($node, $format);

//echo $test;

$context['entity_type_id'] = "fedora_resource";
$context['bundle_type_id'] = "rdf_source";

$entity = Drupal::service("serializer")->deserialize($test, 'Drupal\islandora\Entity\FedoraResource', $format, $context);

$id = $entity->created->value;
echo $id;

// echo "Testing.............. " . $id;

//$test = Drupal::service("serializer")->serialize($entity, $format);
//echo $test;
```


