### PR TITLE
Use ContextGenerator for JSON serializer

### DIFF
--- a/jsonld.services.yml
+++ b/jsonld.services.yml
@@ -6,6 +6,7 @@ services:
       - { name: normalizer, priority: 10 }
   serializer.normalizer.field_item.jsonld:
     class: Drupal\jsonld\Normalizer\FieldItemNormalizer
+    arguments: ['@jsonld.contextgenerator']
     tags:
       - { name: normalizer, priority: 10 }
   serializer.normalizer.field.jsonld:

--- a/jsonld.services.yml
+++ b/jsonld.services.yml
@@ -1,7 +1,7 @@
 services:
   serializer.normalizer.entity_reference_item.jsonld:
     class: Drupal\jsonld\Normalizer\EntityReferenceItemNormalizer
-    arguments: ['@hal.link_manager', '@serializer.entity_resolver']
+    arguments: ['@hal.link_manager', '@serializer.entity_resolver', '@jsonld.contextgenerator']
     tags:
       - { name: normalizer, priority: 10 }
   serializer.normalizer.field_item.jsonld:

--- a/src/ContextGenerator/JsonldContextGenerator.php
+++ b/src/ContextGenerator/JsonldContextGenerator.php
@@ -180,19 +180,7 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
   }
 
   /**
-   * Gets the correct piece of @context for a given entity field.
-   *
-   * @param \Drupal\rdf\RdfMappingInterface $rdfMapping
-   *   Rdf mapping object.
-   * @param string $field_name
-   *   The name of the field.
-   * @param \Drupal\Core\Field\FieldDefinitionInterface $fieldDefinition
-   *   The definition of the field.
-   * @param array $allRdfNameSpaces
-   *   Every RDF prefixed namespace in this Drupal.
-   *
-   * @return array
-   *   Piece of JSON-LD context that supports this field
+   * {@inheritdoc}
    */
   public function getFieldsRdf(RdfMappingInterface $rdfMapping, $field_name, FieldDefinitionInterface $fieldDefinition, array $allRdfNameSpaces) {
     $termDefinition = [];

--- a/src/ContextGenerator/JsonldContextGenerator.php
+++ b/src/ContextGenerator/JsonldContextGenerator.php
@@ -194,7 +194,7 @@ class JsonldContextGenerator implements JsonldContextGeneratorInterface {
    * @return array
    *   Piece of JSON-LD context that supports this field
    */
-  private function getFieldsRdf(RdfMappingInterface $rdfMapping, $field_name, FieldDefinitionInterface $fieldDefinition, array $allRdfNameSpaces) {
+  public function getFieldsRdf(RdfMappingInterface $rdfMapping, $field_name, FieldDefinitionInterface $fieldDefinition, array $allRdfNameSpaces) {
     $termDefinition = [];
     $fieldContextFragment = [];
     $fieldRDFMapping = $rdfMapping->getPreparedFieldMapping($field_name);

--- a/src/ContextGenerator/JsonldContextGeneratorInterface.php
+++ b/src/ContextGenerator/JsonldContextGeneratorInterface.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\jsonld\ContextGenerator;
 
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\rdf\RdfMappingInterface;
 
 /**
@@ -40,5 +41,22 @@ interface JsonldContextGeneratorInterface {
    *    If no RDF mapping exists.
    */
   public function getContext($ids);
+
+  /**
+   * Gets the correct piece of @context for a given entity field.
+   *
+   * @param \Drupal\rdf\RdfMappingInterface $rdfMapping
+   *   Rdf mapping object.
+   * @param string $field_name
+   *   The name of the field.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $fieldDefinition
+   *   The definition of the field.
+   * @param array $allRdfNameSpaces
+   *   Every RDF prefixed namespace in this Drupal.
+   *
+   * @return array
+   *   Piece of JSON-LD context that supports this field
+   */
+  public function getFieldsRdf(RdfMappingInterface $rdfMapping, $field_name, FieldDefinitionInterface $fieldDefinition, array $allRdfNameSpaces);
 
 }

--- a/src/Normalizer/EntityReferenceItemNormalizer.php
+++ b/src/Normalizer/EntityReferenceItemNormalizer.php
@@ -104,20 +104,15 @@ class EntityReferenceItemNormalizer extends FieldItemNormalizer implements UuidR
         $arguments = isset($field_mappings['datatype_callback']['arguments']) ? $field_mappings['datatype_callback']['arguments'] : NULL;
         $values_clean['@value'] = call_user_func($callback, $target_entity, $arguments);
       }
-      $field = $field_item->getParent();
-      $field_context = $this->jsonldContextgenerator->getFieldsRdf(
-        $context['current_entity_rdf_mapping'],
-        $field->getName(),
-        $field->getFieldDefinition(),
-        $context['namespaces']
-      );
-      if (isset($field_context[$field_keys[0]])) {
-        $values_clean = $values_clean + $field_context[$field_keys[0]];
-      }
       // Since getting the to embed entity URL here could be a little bit
       // expensive and would require an helper method
       // i could just borrow it from the $embed result.
       $values_clean['@id'] = key($embedded['@graph']);
+      // Because having a @type for a reference causes problems, we strip that.
+      // This could be removed using headers in future.
+      if (isset($values_clean['@type'])) {
+        unset($values_clean['@type']);
+      }
 
       // The returned structure will be recursively merged into the normalized
       // JSON-LD @Graph.

--- a/src/Normalizer/EntityReferenceItemNormalizer.php
+++ b/src/Normalizer/EntityReferenceItemNormalizer.php
@@ -110,7 +110,9 @@ class EntityReferenceItemNormalizer extends FieldItemNormalizer implements UuidR
         $field->getFieldDefinition(),
         $context['namespaces']
       );
-      $values_clean = $values_clean + $field_context[$field_keys[0]];
+      if (isset($field_context[$field_keys[0]])) {
+        $values_clean = $values_clean + $field_context[$field_keys[0]];
+      }
       // Since getting the to embed entity URL here could be a little bit
       // expensive and would require an helper method
       // i could just borrow it from the $embed result.

--- a/src/Normalizer/EntityReferenceItemNormalizer.php
+++ b/src/Normalizer/EntityReferenceItemNormalizer.php
@@ -81,6 +81,7 @@ class EntityReferenceItemNormalizer extends FieldItemNormalizer implements UuidR
     $embedded = $this->serializer->normalize($target_entity, $format, $context);
 
     if (isset($context['current_entity_rdf_mapping'])) {
+      $values_clean = [];
       // So why i am passing the whole rdf mapping object and not
       // only the predicate? Well because i hope i will be able
       // to MAP to RDF also sub fields of a complex field someday

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -57,7 +57,6 @@ class FieldItemNormalizer extends NormalizerBase {
     else {
       $values_clean['@value'] = $values['value'];
       if (isset($context['current_entity_rdf_mapping'])) {
-        $values_clean = [];
         // So why i am passing the whole rdf mapping object and not
         // only the predicate? Well because i hope i will be able
         // to MAP to RDF also sub fields of a complex field someday

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -82,7 +82,9 @@ class FieldItemNormalizer extends NormalizerBase {
           $field->getFieldDefinition(),
           $context['namespaces']
         );
-        $values_clean = $values_clean + $field_context[$field_keys[0]];
+        if (isset($field_context[$field_keys[0]])) {
+          $values_clean = $values_clean + $field_context[$field_keys[0]];
+        }
 
       }
       else {

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -57,6 +57,7 @@ class FieldItemNormalizer extends NormalizerBase {
     else {
       $values_clean['@value'] = $values['value'];
       if (isset($context['current_entity_rdf_mapping'])) {
+        $values_clean = [];
         // So why i am passing the whole rdf mapping object and not
         // only the predicate? Well because i hope i will be able
         // to MAP to RDF also sub fields of a complex field someday

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -3,6 +3,7 @@
 namespace Drupal\jsonld\Normalizer;
 
 use Drupal\Core\Field\FieldItemInterface;
+use Drupal\jsonld\ContextGenerator\JsonldContextGeneratorInterface;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 /**
@@ -16,6 +17,23 @@ class FieldItemNormalizer extends NormalizerBase {
    * @var string
    */
   protected $supportedInterfaceOrClass = 'Drupal\Core\Field\FieldItemInterface';
+
+  /**
+   * Json-Ld context generator service.
+   *
+   * @var \Drupal\jsonld\ContextGenerator\JsonldContextGeneratorInterface
+   */
+  protected $jsonldContextgenerator;
+
+  /**
+   * FieldItemNormalizer constructor.
+   *
+   * @param \Drupal\jsonld\ContextGenerator\JsonldContextGeneratorInterface $jsonld_context
+   *   Json-Ld context generator service.
+   */
+  public function __construct(JsonldContextGeneratorInterface $jsonld_context) {
+    $this->jsonldContextgenerator = $jsonld_context;
+  }
 
   /**
    * {@inheritdoc}
@@ -58,12 +76,20 @@ class FieldItemNormalizer extends NormalizerBase {
           $arguments = isset($field_mappings['datatype_callback']['arguments']) ? $field_mappings['datatype_callback']['arguments'] : NULL;
           $values_clean['@value'] = call_user_func($callback, $values, $arguments);
         }
+        $field_context = $this->jsonldContextgenerator->getFieldsRdf(
+          $context['current_entity_rdf_mapping'],
+          $field->getName(),
+          $field->getFieldDefinition(),
+          $context['namespaces']
+        );
+        $values_clean = $values_clean + $field_context[$field_keys[0]];
+
       }
       else {
         $field_keys = [$field->getName()];
       }
-
-      if (isset($context['langcode'])) {
+      // JSON-LD Spec says you can't have an @language for a typed values.
+      if (isset($context['langcode']) && !isset($values_clean['@type'])) {
         $values_clean['@language'] = $context['langcode'];
       }
       array_filter($values_clean);
@@ -74,6 +100,10 @@ class FieldItemNormalizer extends NormalizerBase {
         // If there's no context, we need full predicates, not shortened ones.
         if (!$context['needs_jsonldcontext']) {
           $field_name = $this->escapePrefix($field_name, $context['namespaces']);
+          foreach ($values_clean as $key => $val) {
+            // Expand values in the array, ie. @type values xsd:string.
+            $values_clean[$key] = $this->escapePrefix($val, $context['namespaces']);
+          }
         }
         $normalized[$field_name] = [$values_clean];
       }

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -151,11 +151,13 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
 
     $chain_resolver = new ChainEntityResolver([new UuidResolver($entity_manager), new TargetIdResolver()]);
 
+    $jsonld_context_generator = $this->container->get('jsonld.contextgenerator');
+
     // Set up the mock serializer.
     $normalizers = [
       new ContentEntityNormalizer($link_manager, $entity_manager, \Drupal::moduleHandler()),
-      new EntityReferenceItemNormalizer($link_manager, $chain_resolver),
-      new FieldItemNormalizer(),
+      new EntityReferenceItemNormalizer($link_manager, $chain_resolver, $jsonld_context_generator),
+      new FieldItemNormalizer($jsonld_context_generator),
       new FieldNormalizer(),
     ];
 

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -72,27 +72,25 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
           'http://purl.org/dc/terms/title' => [
             [
               '@value' => $values['name'],
-              '@type' => 'xsd:string',
-              '@language' => 'en',
+              '@type' => 'http://www.w3.org/2001/XMLSchema#string',
             ],
           ],
           'http://schema.org/dateCreated' => [
             [
               '@value' => $iso,
-              '@type' => 'xsd:dateTime',
-              '@language' => 'en',
+              '@type' => 'http://www.w3.org/2001/XMLSchema#dateTime',
             ],
           ],
           'http://purl.org/dc/terms/abstract' => [
             [
               '@value' => $values['field_test_text']['value'],
-              '@type' => 'xsd:string',
+              '@type' => 'http://www.w3.org/2001/XMLSchema#string',
             ],
           ],
           'http://purl.org/dc/terms/references' => [
             [
               '@id' => $this->getEntityUri($target_entity),
-              '@type' => 'xsd:nonNegativeInteger',
+              '@type' => 'http://www.w3.org/2001/XMLSchema#nonNegativeInteger',
             ],
           ],
         ],


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/661

# What does this Pull Request do?

Uses Json-ld Context Generator for normalizer.

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository
(ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

1. Bring up CLAW
1. Add an Islandora Image with some metadata (image not required)
1. View the Json-ld version (ie. http://localhost:8000/node/1?_format=jsonld)
1. Then pull down this PR over jsonld
1. In terminal go to Drupal home, `cd /var/www/html/drupal/web` (for vagrant)
1. Run `drupal router:rebuild`
1. Run `drupal cache:rebuild all`
1. Reload the above web page (http://localhost:8000/node/1?_format=jsonld)
1. See new `@type` properties.
```
http://purl.org/dc/terms/title: [
    {
        @value: "Test Image",
        @type: "http://www.w3.org/2001/XMLSchema#string"
    }
],
```

# Additional Notes:
Any additional information that you think would be helpful when reviewing this 
PR.

# Interested parties
@DiegoPino @dannylamb @ajs6f 
