### PR TITLE
issue 808: make xsd:string implicit so we can add @language to those properties

### DIFF
--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -67,6 +67,7 @@ class FieldItemNormalizer extends NormalizerBase {
         // JSON-LD xsd:string https://json-ld.org/spec/latest/json-ld/#dfn-strings. 
         // Getting rid of @type to allow @language 
         // @see https://json-ld.org/spec/latest/json-ld/#string-internationalization
+        dpm($field_mappings);
         if (!empty($field_mappings['datatype']) && $field_mappings['datatype'] != "xsd:string"){
           $values_clean['@type'] = $field_mappings['datatype'];
         }

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -63,7 +63,11 @@ class FieldItemNormalizer extends NormalizerBase {
         // and somehow.
         $field_mappings = $context['current_entity_rdf_mapping']->getPreparedFieldMapping($field->getName());
         $field_keys = isset($field_mappings['properties']) ? $field_mappings['properties'] : [$field->getName()];
-        if (!empty($field_mappings['datatype'])) {
+
+        // JSON-LD xsd:string https://json-ld.org/spec/latest/json-ld/#dfn-strings. 
+        // Getting rid of @type to allow @language 
+        // @see https://json-ld.org/spec/latest/json-ld/#string-internationalization
+        if (!empty($field_mappings['datatype']) && $field_mappings['datatype'] != "xsd:string"){
           $values_clean['@type'] = $field_mappings['datatype'];
         }
 

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -67,7 +67,7 @@ class FieldItemNormalizer extends NormalizerBase {
         // JSON-LD xsd:string https://json-ld.org/spec/latest/json-ld/#dfn-strings. 
         // Getting rid of @type to allow @language 
         // @see https://json-ld.org/spec/latest/json-ld/#string-internationalization
-        print_r($field_mappings);
+        print_r($field_mappings['datatype']);
         if (!empty($field_mappings['datatype']) && $field_mappings['datatype'] != "xsd:string"){
           $values_clean['@type'] = $field_mappings['datatype'];
         }

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -122,8 +122,6 @@ class FieldItemNormalizer extends NormalizerBase {
         }
         $normalized[$field_name] = [$values_clean];
       }
-      print_r($normalized);
-
       return $normalized;
     }
   }

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -90,6 +90,7 @@ class FieldItemNormalizer extends NormalizerBase {
           $field->getFieldDefinition(),
           $context['namespaces']
         );
+        print_r("my computed context");
         print_r($field_context);
         if (isset($field_context[$field_keys[0]])) {
           $values_clean = $values_clean + $field_context[$field_keys[0]];

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -66,7 +66,9 @@ class FieldItemNormalizer extends NormalizerBase {
 
         // Getting rid of @type to allow @language
         // @see https://json-ld.org/spec/latest/json-ld/#string-internationalization
+        print_r("current_entity_rdf_mapping");
         print_r($field_mappings);
+        
         if (!empty($field_mappings['datatype'])
           && $field_mappings['datatype'] != "xsd:string"
           &&  $field_mappings['datatype'] != "http://www.w3.org/2001/XMLSchema#string") {

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -67,7 +67,7 @@ class FieldItemNormalizer extends NormalizerBase {
         // JSON-LD xsd:string https://json-ld.org/spec/latest/json-ld/#dfn-strings. 
         // Getting rid of @type to allow @language 
         // @see https://json-ld.org/spec/latest/json-ld/#string-internationalization
-        dpm($field_mappings);
+        print_r($field_mappings);
         if (!empty($field_mappings['datatype']) && $field_mappings['datatype'] != "xsd:string"){
           $values_clean['@type'] = $field_mappings['datatype'];
         }
@@ -114,7 +114,8 @@ class FieldItemNormalizer extends NormalizerBase {
         }
         $normalized[$field_name] = [$values_clean];
       }
-
+      print_r($normalized);
+     
       return $normalized;
     }
   }

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -67,7 +67,7 @@ class FieldItemNormalizer extends NormalizerBase {
         // JSON-LD xsd:string https://json-ld.org/spec/latest/json-ld/#dfn-strings. 
         // Getting rid of @type to allow @language 
         // @see https://json-ld.org/spec/latest/json-ld/#string-internationalization
-        print_r($field_mappings['datatype']);
+        print_r($field_mappings);
         if (!empty($field_mappings['datatype']) && $field_mappings['datatype'] != "xsd:string"){
           $values_clean['@type'] = $field_mappings['datatype'];
         }
@@ -95,6 +95,7 @@ class FieldItemNormalizer extends NormalizerBase {
       else {
         $field_keys = [$field->getName()];
       }
+      print_r($field_keys);
       // JSON-LD Spec says you can't have an @language for a typed values.
       if (isset($context['langcode']) && !isset($values_clean['@type'])) {
         $values_clean['@language'] = $context['langcode'];

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -64,11 +64,12 @@ class FieldItemNormalizer extends NormalizerBase {
         $field_mappings = $context['current_entity_rdf_mapping']->getPreparedFieldMapping($field->getName());
         $field_keys = isset($field_mappings['properties']) ? $field_mappings['properties'] : [$field->getName()];
 
-        // JSON-LD xsd:string https://json-ld.org/spec/latest/json-ld/#dfn-strings. 
-        // Getting rid of @type to allow @language 
+        // Getting rid of @type to allow @language
         // @see https://json-ld.org/spec/latest/json-ld/#string-internationalization
         print_r($field_mappings);
-        if (!empty($field_mappings['datatype']) && $field_mappings['datatype'] != "xsd:string"){
+        if (!empty($field_mappings['datatype'])
+          && $field_mappings['datatype'] != "xsd:string"
+          &&  $field_mappings['datatype'] != "http://www.w3.org/2001/XMLSchema#string") {
           $values_clean['@type'] = $field_mappings['datatype'];
         }
 
@@ -87,6 +88,7 @@ class FieldItemNormalizer extends NormalizerBase {
           $field->getFieldDefinition(),
           $context['namespaces']
         );
+        print_r($field_context);
         if (isset($field_context[$field_keys[0]])) {
           $values_clean = $values_clean + $field_context[$field_keys[0]];
         }
@@ -116,7 +118,7 @@ class FieldItemNormalizer extends NormalizerBase {
         $normalized[$field_name] = [$values_clean];
       }
       print_r($normalized);
-     
+
       return $normalized;
     }
   }

--- a/tests/src/Kernel/JsonldContextGeneratorTest.php
+++ b/tests/src/Kernel/JsonldContextGeneratorTest.php
@@ -23,7 +23,6 @@ class JsonldContextGeneratorTest extends KernelTestBase {
     'rdf_test_namespaces',
     'serialization',
     'system',
-    'typed_data',
   ];
 
 

--- a/tests/src/Kernel/JsonldContextGeneratorTest.php
+++ b/tests/src/Kernel/JsonldContextGeneratorTest.php
@@ -16,7 +16,6 @@ use Drupal\KernelTests\KernelTestBase;
 class JsonldContextGeneratorTest extends KernelTestBase {
 
   public static $modules = [
-    'entity',
     'entity_test',
     'hal',
     'jsonld',

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -19,6 +19,9 @@ use Drupal\serialization\EntityResolver\ChainEntityResolver;
 use Drupal\serialization\EntityResolver\TargetIdResolver;
 use Drupal\serialization\EntityResolver\UuidResolver;
 use Symfony\Component\Serializer\Serializer;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\TypedData\TranslationStatusInterface;
+use Drupal\language\Entity\ConfigurableLanguage;
 
 /**
  * Base class for Json-LD Kernel tests.

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -40,6 +40,7 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
     'entity_test',
     'text',
     'jsonld',
+    'language',
   ];
 
   /**
@@ -69,14 +70,48 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
    * @var \Drupal\rdf\Entity\RdfMapping
    */
   protected $rdfMapping;
+  
+  /**
+   * The language manager service.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+  * The available language codes.
+  *
+  * @var array
+  */
+  protected $langcodes;
+  
 
   /**
    * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();
+    $this->languageManager = $this->container->get('language_manager');
     $this->installEntitySchema('user');
     $this->installEntitySchema('entity_test');
+    
+    // Create the default languages.
+    $this->installConfig(['language']);
+
+    // Create test languages.
+    $this->langcodes = ['en-ca','es-cl'];
+    foreach ($this->langcodes as $key => $fakelang) {
+      $language = ConfigurableLanguage::create([
+        'id' => $fakelang,
+        'label' => $fakelang,
+        'weight' => $key,
+      ]);
+      $this->langcodes[$key] = $language->getId();
+      $language->save();
+    }
+
+    $this->state->set('entity_test.translation', TRUE);
+
     $class = get_class($this);
     while ($class) {
       if (property_exists($class, 'modules')) {
@@ -127,7 +162,7 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
       'entity_type' => 'entity_test',
       'field_name' => 'field_test_text',
       'bundle' => 'entity_test',
-      'translatable' => FALSE,
+      'translatable' => TRUE,
     ])->save();
 
     // Create the test entity reference field.

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -19,8 +19,6 @@ use Drupal\serialization\EntityResolver\ChainEntityResolver;
 use Drupal\serialization\EntityResolver\TargetIdResolver;
 use Drupal\serialization\EntityResolver\UuidResolver;
 use Symfony\Component\Serializer\Serializer;
-use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\TypedData\TranslationStatusInterface;
 use Drupal\language\Entity\ConfigurableLanguage;
 
 /**
@@ -83,7 +81,7 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
 
     $this->installEntitySchema('user');
     $this->installEntitySchema('entity_test');
-    
+
     // Create the default languages.
     $this->installConfig(['language']);
     $this->installEntitySchema('configurable_language');

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -149,6 +149,7 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
       'field_name' => 'field_test_entity_reference',
       'entity_type' => 'entity_test',
       'type' => 'entity_reference',
+      'translatable' => FALSE,
       'settings' => [
         'target_type' => 'entity_test',
       ],

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -44,6 +44,7 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
     'text',
     'jsonld',
     'language',
+    'content_translation',
   ];
 
   /**
@@ -73,47 +74,22 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
    * @var \Drupal\rdf\Entity\RdfMapping
    */
   protected $rdfMapping;
-  
-  /**
-   * The language manager service.
-   *
-   * @var \Drupal\Core\Language\LanguageManagerInterface
-   */
-  protected $languageManager;
-
-  /**
-  * The available language codes.
-  *
-  * @var array
-  */
-  protected $langcodes;
-  
 
   /**
    * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();
-    $this->languageManager = $this->container->get('language_manager');
+
     $this->installEntitySchema('user');
     $this->installEntitySchema('entity_test');
     
     // Create the default languages.
     $this->installConfig(['language']);
+    $this->installEntitySchema('configurable_language');
 
     // Create test languages.
-    $this->langcodes = ['en-ca','es-cl'];
-    foreach ($this->langcodes as $key => $fakelang) {
-      $language = ConfigurableLanguage::create([
-        'id' => $fakelang,
-        'label' => $fakelang,
-        'weight' => $key,
-      ]);
-      $this->langcodes[$key] = $language->getId();
-      $language->save();
-    }
-
-    $this->state->set('entity_test.translation', TRUE);
+    ConfigurableLanguage::createFromLangcode('es')->save();
 
     $class = get_class($this);
     while ($class) {

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -153,18 +153,18 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
    */
   public function testLocalizedNormalizeJsonld() {
 
-    $target_entity = EntityTest::create([
+    $target_entity_tl = EntityTest::create([
       'name' => $this->randomMachineName(),
-      'langcode' => 'en',
+      'langcode' => 'ho',
       'field_test_entity_reference' => NULL,
     ]);
-    $target_entity->save();
+    $target_entity_tl->save();
 
-    $target_user = User::create([
-      'name' => $this->randomMachineName(),
-      'langcode' => 'en',
+    $target_user_tl = User::create([
+      'name' => 'Tooh',
+      'langcode' => 'ho',
     ]);
-    $target_user->save();
+    $target_user_tl->save();
 
     rdf_get_mapping('entity_test', 'entity_test')->setBundleMapping(
       [
@@ -174,7 +174,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
       ])->setFieldMapping('field_test_text', [
         'properties' => ['dc:description'],
       ])->setFieldMapping('user_id', [
-        'properties' => ['schema:author'],
+        'properties' => ['schema:contributor'],
       ])->setFieldMapping('modified', [
         'properties' => ['schema:dateModified'],
         'datatype' => 'xsd:dateTime',
@@ -190,7 +190,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
       'name' => 'In Canadian english',
       'type' => 'entity_test',
       'bundle' => 'entity_test',
-      'user_id' => $target_user->id(),
+      'user_id' => $target_user_tl->id(),
       'created' => [
         'value' => $created,
       ],
@@ -199,10 +199,10 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
         'format' => 'full_html',
       ],
       'field_test_entity_reference' => [
-        'target_id' => $target_entity->id(),
+        'target_id' => $target_entity_tl->id(),
       ],
     ];
-    
+
     $valores = [
       'name' => 'En Castellano de Chile',
       'field_test_text' => [
@@ -210,19 +210,18 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
         'format' => 'full_html',
       ],
       'field_test_entity_reference' => [
-        'target_id' => $target_entity->id(),
+        'target_id' => $target_entity_tl->id(),
       ],
     ];
 
-    $entity = EntityTest::create($values);
-    $entity->save();
-    $existing_entity_values = $entity->toArray();
-    
-    // Note: Drupal also generates a new date create and author 
+    $entity_tl = EntityTest::create($values);
+    $entity_tl->save();
+    $existing_entity_values = $entity_tl->toArray();
+
+    // Note: Drupal also generates a new date create and author
     // When translating but we can't mark that with @language
-    
-    $translated_entity_array = array_merge($existing_entity_values , $valores);
-    $entity->addTranslation('es', $translated_entity_array)->save();
+    $translated_entity_array = array_merge($existing_entity_values, $valores);
+    $entity_tl->addTranslation('es', $translated_entity_array)->save();
 
     $expected = [
       "@graph" => [
@@ -256,12 +255,12 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
               "@language" => "es",
             ],
           ],
-          "http://schema.org/author" => [
+          "http://schema.org/contributor" => [
             [
-              "@id" => $this->getEntityUri($target_user),
+              "@id" => $this->getEntityUri($target_user_tl),
             ],
             [
-              "@id" => $this->getEntityUri($target_user),
+              "@id" => $this->getEntityUri($target_user_tl),
             ],
           ],
           "http://schema.org/dateCreated" => [
@@ -276,11 +275,11 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
           ],
         ],
         [
-          "@id" => $this->getEntityUri($target_user),
+          "@id" => $this->getEntityUri($target_user_tl),
           "@type" => "http://localhost/rest/type/user/user",
         ],
         [
-          "@id" => $this->getEntityUri($target_entity),
+          "@id" => $this->getEntityUri($target_entity_tl),
           "@type" => [
             "http://schema.org/ImageObject",
           ],
@@ -288,7 +287,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
       ],
     ];
 
-    $normalized = $this->serializer->normalize($entity, $this->format);
+    $normalized = $this->serializer->normalize($entity_tl, $this->format);
 
     $this->assertEquals($expected, $normalized, "Did not normalize correctly.");
 

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -101,14 +101,153 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
           ],
           "http://purl.org/dc/terms/description" => [
             [
-              "@type" => "http://www.w3.org/2001/XMLSchema#string",
               "@value" => $values['field_test_text']['value'],
             ],
           ],
           "http://purl.org/dc/terms/title" => [
             [
-              "@type" => "http://www.w3.org/2001/XMLSchema#string",
               "@value" => $values['name'],
+            ],
+          ],
+          "http://schema.org/author" => [
+            [
+              "@id" => $this->getEntityUri($target_user),
+            ],
+          ],
+          "http://schema.org/dateCreated" => [
+            [
+              "@type" => "http://www.w3.org/2001/XMLSchema#dateTime",
+              "@value" => $created_iso,
+            ],
+          ],
+        ],
+        [
+          "@id" => $this->getEntityUri($target_user),
+          "@type" => "http://localhost/rest/type/user/user",
+        ],
+        [
+          "@id" => $this->getEntityUri($target_entity),
+          "@type" => [
+            "http://schema.org/ImageObject",
+          ],
+        ],
+      ],
+    ];
+
+    $normalized = $this->serializer->normalize($entity, $this->format);
+    $this->assertEquals($expected, $normalized, "Did not normalize correctly.");
+
+  }
+
+  /**
+   * @covers \Drupal\jsonld\Normalizer\NormalizerBase::supportsNormalization
+   * @covers \Drupal\jsonld\Normalizer\NormalizerBase::escapePrefix
+   * @covers \Drupal\jsonld\Normalizer\ContentEntityNormalizer::normalize
+   * @covers \Drupal\jsonld\Normalizer\ContentEntityNormalizer::getEntityUri
+   * @covers \Drupal\jsonld\Normalizer\FieldNormalizer::normalize
+   * @covers \Drupal\jsonld\Normalizer\FieldNormalizer::normalizeFieldItems
+   * @covers \Drupal\jsonld\Normalizer\FieldItemNormalizer::normalize
+   * @covers \Drupal\jsonld\Normalizer\EntityReferenceItemNormalizer::normalize
+   */
+  public function testLocalizedNormalizeJsonld() {
+
+    $target_entity = EntityTest::create([
+      'name' => $this->randomMachineName(),
+      'langcode' => 'en',
+      'field_test_entity_reference' => NULL,
+    ]);
+    $target_entity->save();
+
+    $target_user = User::create([
+      'name' => $this->randomMachineName(),
+      'langcode' => 'en',
+    ]);
+    $target_user->save();
+
+    rdf_get_mapping('entity_test', 'entity_test')->setBundleMapping(
+      [
+        'types' => [
+          "schema:ImageObject",
+        ],
+      ])->setFieldMapping('field_test_text', [
+        'properties' => ['dc:description'],
+      ])->setFieldMapping('user_id', [
+        'properties' => ['schema:author'],
+      ])->setFieldMapping('modified', [
+        'properties' => ['schema:dateModified'],
+        'datatype' => 'xsd:dateTime',
+      ])->save();
+
+    $tz = new \DateTimeZone('UTC');
+    $dt = new \DateTime(NULL, $tz);
+    $created = $dt->format("U");
+    $created_iso = $dt->format(\DateTime::W3C);
+    // Create an entity.
+    $values = [
+      'langcode' => 'en',
+      'name' => 'In english',
+      'type' => 'entity_test',
+      'bundle' => 'entity_test',
+      'user_id' => $target_user->id(),
+      'created' => [
+        'value' => $created,
+      ],
+      'field_test_text' => [
+        'value' => 'Dude',
+        'format' => 'full_html',
+      ],
+      'field_test_entity_reference' => [
+        'target_id' => $target_entity->id(),
+      ],
+    ];
+    
+    $valores = [
+      'name' => 'En español',
+      'field_test_text' => [
+        'value' => 'Muchacho',
+        'format' => 'full_html',
+      ],
+      'field_test_entity_reference' => [
+        'target_id' => $target_entity->id(),
+      ],
+    ];
+
+    $entity = EntityTest::create($values);
+    $entity->save();
+    $existing_entity_values = $entity->toArray();
+    $translated_entity_array = array_merge($existing_entity_values , $valores);
+    $entity->addTranslation('es', $translated_entity_array)->save();
+
+    $expected = [
+      "@graph" => [
+        [
+          "@id" => $this->getEntityUri($entity),
+          "@type" => [
+            'http://schema.org/ImageObject',
+          ],
+          "http://purl.org/dc/terms/references" => [
+            [
+              "@id" => $this->getEntityUri($target_entity),
+            ],
+          ],
+          "http://purl.org/dc/terms/description" => [
+            [
+              "@value" => "Dude",
+              "@language" => "en",
+            ],
+            [
+              "@value" => "Muchacho",
+              "@language" => "es",
+            ],
+          ],
+          "http://purl.org/dc/terms/title" => [
+            [
+              "@value" => "In english",
+              "@language" => "en",
+            ],
+            [
+              "@value" => "En español",
+              "@language" => "es",
             ],
           ],
           "http://schema.org/author" => [

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -184,8 +184,8 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
     $created_iso = $dt->format(\DateTime::W3C);
     // Create an entity.
     $values = [
-      'langcode' => 'en-ca',
-      'name' => 'In english',
+      'langcode' => 'en',
+      'name' => 'In Canadian english',
       'type' => 'entity_test',
       'bundle' => 'entity_test',
       'user_id' => $target_user->id(),
@@ -202,7 +202,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
     ];
     
     $valores = [
-      'name' => 'En español',
+      'name' => 'En Castellano de Chile',
       'field_test_text' => [
         'value' => 'Muchacho',
         'format' => 'full_html',
@@ -246,7 +246,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
               "@language" => "en",
             ],
             [
-              "@value" => "En español de Chile",
+              "@value" => "En Castellano de Chile",
               "@language" => "es",
             ],
           ],

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -232,7 +232,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
           ],
           "http://purl.org/dc/terms/references" => [
             [
-              "@id" => $this->getEntityUri($target_entity),
+              "@id" => $this->getEntityUri($target_entity_tl),
             ],
           ],
           "http://purl.org/dc/terms/description" => [

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -216,7 +216,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
     $entity->save();
     $existing_entity_values = $entity->toArray();
     $translated_entity_array = array_merge($existing_entity_values , $valores);
-    $entity->addTranslation('es-cl', $translated_entity_array)->save();
+    $entity->addTranslation('es', $translated_entity_array)->save();
 
     $expected = [
       "@graph" => [
@@ -233,21 +233,21 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
           "http://purl.org/dc/terms/description" => [
             [
               "@value" => "Dude",
-              "@language" => "en-ca",
+              "@language" => "en",
             ],
             [
               "@value" => "Muchacho",
-              "@language" => "es-cl",
+              "@language" => "es",
             ],
           ],
           "http://purl.org/dc/terms/title" => [
             [
               "@value" => "In Canadian english",
-              "@language" => "en-ca",
+              "@language" => "en",
             ],
             [
               "@value" => "En español de Chile",
-              "@language" => "es-cl",
+              "@language" => "es",
             ],
           ],
           "http://schema.org/author" => [

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -226,7 +226,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
     $expected = [
       "@graph" => [
         [
-          "@id" => $this->getEntityUri($entity),
+          "@id" => $this->getEntityUri($entity_tl),
           "@type" => [
             'http://schema.org/ImageObject',
           ],

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -217,6 +217,10 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
     $entity = EntityTest::create($values);
     $entity->save();
     $existing_entity_values = $entity->toArray();
+    
+    // Note: Drupal also generates a new date create and author 
+    // When translating but we can't mark that with @language
+    
     $translated_entity_array = array_merge($existing_entity_values , $valores);
     $entity->addTranslation('es', $translated_entity_array)->save();
 
@@ -256,8 +260,15 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
             [
               "@id" => $this->getEntityUri($target_user),
             ],
+            [
+              "@id" => $this->getEntityUri($target_user),
+            ],
           ],
           "http://schema.org/dateCreated" => [
+            [
+              "@type" => "http://www.w3.org/2001/XMLSchema#dateTime",
+              "@value" => $created_iso,
+            ],
             [
               "@type" => "http://www.w3.org/2001/XMLSchema#dateTime",
               "@value" => $created_iso,
@@ -278,7 +289,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
     ];
 
     $normalized = $this->serializer->normalize($entity, $this->format);
-    print_r($normalized);
+
     $this->assertEquals($expected, $normalized, "Did not normalize correctly.");
 
   }

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -184,7 +184,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
     $created_iso = $dt->format(\DateTime::W3C);
     // Create an entity.
     $values = [
-      'langcode' => 'en',
+      'langcode' => 'en-ca',
       'name' => 'In english',
       'type' => 'entity_test',
       'bundle' => 'entity_test',
@@ -216,7 +216,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
     $entity->save();
     $existing_entity_values = $entity->toArray();
     $translated_entity_array = array_merge($existing_entity_values , $valores);
-    $entity->addTranslation('es', $translated_entity_array)->save();
+    $entity->addTranslation('es-cl', $translated_entity_array)->save();
 
     $expected = [
       "@graph" => [
@@ -233,21 +233,21 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
           "http://purl.org/dc/terms/description" => [
             [
               "@value" => "Dude",
-              "@language" => "en",
+              "@language" => "en-ca",
             ],
             [
               "@value" => "Muchacho",
-              "@language" => "es",
+              "@language" => "es-cl",
             ],
           ],
           "http://purl.org/dc/terms/title" => [
             [
-              "@value" => "In english",
-              "@language" => "en",
+              "@value" => "In Canadian english",
+              "@language" => "en-ca",
             ],
             [
-              "@value" => "En español",
-              "@language" => "es",
+              "@value" => "En español de Chile",
+              "@language" => "es-cl",
             ],
           ],
           "http://schema.org/author" => [

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -102,11 +102,13 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
           "http://purl.org/dc/terms/description" => [
             [
               "@value" => $values['field_test_text']['value'],
+              "@language" => "en",
             ],
           ],
           "http://purl.org/dc/terms/title" => [
             [
               "@value" => $values['name'],
+              "@language" => "en",
             ],
           ],
           "http://schema.org/author" => [

--- a/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
+++ b/tests/src/Kernel/Normalizer/ContentEntityNormalizerTests.php
@@ -278,6 +278,7 @@ class ContentEntityNormalizerTests extends JsonldKernelTestBase {
     ];
 
     $normalized = $this->serializer->normalize($entity, $this->format);
+    print_r($normalized);
     $this->assertEquals($expected, $normalized, "Did not normalize correctly.");
 
   }


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora-CLAW/CLAW/issues/808)

* https://groups.google.com/forum/#!topic/islandora/5vWtk42F1YA

# What does this Pull Request do?

JSON-LD specs disallow @language key to coexist with the @type one. See https://json-ld.org/spec/latest/json-ld/#string-internationalization (notes at the end)
Since we are actually type-casting everything in our serializer to be RDF compliant and we need to support translated entities, this pull removes @type for strings in the field item serializer and relays on the implicit casting of JSON.

# What's new?
* You will get @language tags for every xsd:string type field. 
* Tests were updated (yes sir, I write tests) for translation reality
* jsonldContext tests were also cleaned
* removing xsd:string happens just before returning normalized field item

* Does this change require documentation to be updated? 
No? do we have docs for this?
* Does this change add any new dependencies? 
Not I'm aware of. 
* Does this change require any other modifications to be made to the repository
(ie. Regeneration activity, etc.)? 
Please clear your caches and run the test. Also, yes, your triples will change for sure. You will get a lot of "@en" for things that you never knew that was in the English language.
* Could this change impact execution of existing code?
Pretty sure not, but any code (not PHP, dunno?) that actually updates the triple store should be aware that @language key is a thing now and should avoid stripping it out.

# How should this be tested?

So many ways. I assume here you already have JSONLD serialization working.

- Run the tests. They should pass. They did pass here using Drupal 8.4. Not first time i wrote them of course, but after like 10 commits and some duck tape.

- Enable translation, languages, etc. Make one of your content types (like an article?) translateable and allow for an extra language (i recommend Spanish, makes everything work much better...)
- Create a new article in English, add then a translation in the language you selected in the previous step.
- ```curl  -i -v yourdomain.something/node/$nodenumber?_format=jsonld```

See the light and use a dictionary, if possible, to understand the new awesomeness of having translated fields.

# Additional Notes:
There is an issue. Once the translation is enabled, fields like author and dateCreated are duplicated for every translation. But (this is just RDF, not SpaceX so don't demand more) we have no way of stating which value belongs to which translation. So you will get duplicates there. The only idea I could have there is to dedupe if values are the same... but that is another topic, another pull, another day.

**As always, please SQUASH and merge. I left all my failures, errors and test commits in this branch to encourage people to never be ashamed of late night coding**

# Interested parties
@Islandora-CLAW/committers @whikloj @dannylamb @Natkeeran 

