### PR TITLE
updating travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ![CLAW-JSON-LD](https://cloud.githubusercontent.com/assets/2371345/24964530/f054bddc-1f77-11e7-8b54-d04bb7b2281c.png) JSONLD
-[![Build Status][1]](https://travis-ci.org/Islandora-CLAW/jsonld)
+[![Build Status][1]](https://travis-ci.com/Islandora-CLAW/jsonld)
 [![Contribution Guidelines][2]](./CONTRIBUTING.md)
 [![LICENSE][3]](./LICENSE)
 


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#950

# What does this Pull Request do?

Grabs the travis badge from travis-ci.com instead of travis-ci.org

# Interested parties
@Islandora-CLAW/committers
