### PR TITLE
Add configuration form to remove ?_format=jsonld from @ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ This module adds a simple Drupal entity to JSON-LD
 classes. It depends on RDF module and existing fields to rdf properties 
 mappings to do it's job.
 
+## Configuration
+
+The JSON-LD normalizer adds a `?_format=jsonld` to all URIs by default.
+
+You can disable this via a checkbox in the Configuration -> Search and Metadata -> JsonLD form.
+
 ## Maintainers
 
 Current maintainers:

--- a/config/install/jsonld.settings.yml
+++ b/config/install/jsonld.settings.yml
@@ -1,0 +1,1 @@
+remove_jsonld_format: 0

--- a/config/install/jsonld.settings.yml
+++ b/config/install/jsonld.settings.yml
@@ -1,1 +1,1 @@
-remove_jsonld_format: 0
+remove_jsonld_format: false

--- a/config/schema/jsonld.schema.yml
+++ b/config/schema/jsonld.schema.yml
@@ -3,5 +3,5 @@ jsonld.settings:
   label: 'JSONLD Settings'
   mapping:
     remove_jsonld_format:
-      type: bool 
+      type: boolean 
       label: 'If checked, ?_format=jsonld will be stripped from the end of urls in JSONLD'

--- a/config/schema/jsonld.schema.yml
+++ b/config/schema/jsonld.schema.yml
@@ -1,0 +1,7 @@
+jsonld.settings:
+  type: config_object
+  label: 'JSONLD Settings'
+  mapping:
+    remove_jsonld_format:
+      type: bool 
+      label: 'If checked, ?_format=jsonld will be stripped from the end of urls in JSONLD'

--- a/jsonld.links.menu.yml
+++ b/jsonld.links.menu.yml
@@ -1,0 +1,6 @@
+# Core configuration form
+system.jsonld_settings:
+  title: 'JsonLD'
+  parent: system.admin_config_search
+  route_name: system.jsonld_settings
+  description: 'Configure Jsonld settings'

--- a/jsonld.routing.yml
+++ b/jsonld.routing.yml
@@ -5,3 +5,12 @@ jsonld.context:
     _controller: '\Drupal\jsonld\Controller\JsonldContextController::content'
   requirements:
      _permission: 'access content'
+
+# Core Jsonld configuration form
+system.jsonld_settings:
+  path: '/admin/config/search/jsonld'
+  defaults:
+    _form: '\Drupal\jsonld\Form\JsonLdSettingsForm'
+    _title: 'JsonLD Settings'
+  requirements:
+    _permission: 'administer site configuration'

--- a/jsonld.services.yml
+++ b/jsonld.services.yml
@@ -17,10 +17,10 @@ services:
     class: Drupal\jsonld\Normalizer\FileEntityNormalizer
     tags:
       - { name: normalizer, priority: 20 }
-    arguments: ['@entity_type.manager', '@http_client', '@hal.link_manager', '@module_handler', '@file_system']
+    arguments: ['@entity_type.manager', '@http_client', '@hal.link_manager', '@module_handler', '@file_system', '@config.factory']
   serializer.normalizer.entity.jsonld:
     class: Drupal\jsonld\Normalizer\ContentEntityNormalizer
-    arguments: ['@hal.link_manager', '@entity_type.manager', '@module_handler']
+    arguments: ['@hal.link_manager', '@entity_type.manager', '@module_handler', '@config.factory']
     tags:
       - { name: normalizer, priority: 10 }
   serializer.encoder.jsonld:

--- a/src/Form/JsonLdSettingsForm.php
+++ b/src/Form/JsonLdSettingsForm.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\jsonld\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class JsonLdSettingsForm.
+ *
+ * @package Drupal\jsonld\Form
+ */
+class JsonLdSettingsForm extends ConfigFormBase {
+
+  const CONFIG_NAME = 'jsonld.settings';
+
+  const REMOVE_JSONLD_FORMAT = 'remove_jsonld_format';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      self::CONFIG_NAME,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'jsonld_admin_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(self::CONFIG_NAME);
+    $form = [
+      self::REMOVE_JSONLD_FORMAT => [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Remove jsonld parameter from @ids'),
+        '#description' => $this->t('This will alter any @id parameters to remove "?_format=jsonld"'),
+        '#default_value' => $config->get(self::REMOVE_JSONLD_FORMAT) ? $config->get(self::REMOVE_JSONLD_FORMAT) : FALSE,
+      ],
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = $this->configFactory->getEditable(self::CONFIG_NAME);
+    $config->set(self::REMOVE_JSONLD_FORMAT, $form_state->getValue(self::REMOVE_JSONLD_FORMAT))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/src/Normalizer/FileEntityNormalizer.php
+++ b/src/Normalizer/FileEntityNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\jsonld\Normalizer;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\File\FileSystemInterface;
@@ -47,14 +48,17 @@ class FileEntityNormalizer extends ContentEntityNormalizer {
    *   The module handler.
    * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   The file system handler.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
    */
   public function __construct(EntityTypeManagerInterface $entity_manager,
                               ClientInterface $http_client,
                               LinkManagerInterface $link_manager,
                               ModuleHandlerInterface $module_handler,
-                              FileSystemInterface $file_system) {
+                              FileSystemInterface $file_system,
+                              ConfigFactoryInterface $config_factory) {
 
-    parent::__construct($link_manager, $entity_manager, $module_handler);
+    parent::__construct($link_manager, $entity_manager, $module_handler, $config_factory);
 
     $this->httpClient = $http_client;
     $this->fileSystem = $file_system;

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -170,7 +170,7 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
 
     // Set up the mock serializer.
     $normalizers = [
-      new ContentEntityNormalizer($link_manager, $entity_manager, \Drupal::moduleHandler(),  \Drupal::service('config.factory')),
+      new ContentEntityNormalizer($link_manager, $entity_manager, \Drupal::moduleHandler(), \Drupal::service('config.factory')),
       new EntityReferenceItemNormalizer($link_manager, $chain_resolver, $jsonld_context_generator),
       new FieldItemNormalizer($jsonld_context_generator),
       new FieldNormalizer(),

--- a/tests/src/Kernel/JsonldKernelTestBase.php
+++ b/tests/src/Kernel/JsonldKernelTestBase.php
@@ -170,7 +170,7 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
 
     // Set up the mock serializer.
     $normalizers = [
-      new ContentEntityNormalizer($link_manager, $entity_manager, \Drupal::moduleHandler()),
+      new ContentEntityNormalizer($link_manager, $entity_manager, \Drupal::moduleHandler(),  \Drupal::service('config.factory')),
       new EntityReferenceItemNormalizer($link_manager, $chain_resolver, $jsonld_context_generator),
       new FieldItemNormalizer($jsonld_context_generator),
       new FieldNormalizer(),
@@ -190,6 +190,9 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
    *
    * @return string
    *   The entity URI.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   *   The toUrl() call fails.
    */
   protected function getEntityUri(EntityInterface $entity) {
 
@@ -207,6 +210,11 @@ abstract class JsonldKernelTestBase extends KernelTestBase {
    *
    * @return array
    *   with [ the entity, the normalized array ].
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   *   Problem saving the entity.
+   * @throws \Exception
+   *   Problem creating a DateTime.
    */
   protected function generateTestEntity() {
     $target_entity = EntityTest::create([


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/887

Supersedes https://github.com/Islandora-CLAW/jsonld/pull/32

# What does this Pull Request do?

**This is the same code as https://github.com/Islandora-CLAW/jsonld/pull/32 but on the Foundation's repo so that it can be tested with claw-playbook.**

Makes a configuration choice of whether the URIs output by the Drupal normalizer contain the `_format=jsonld` parameter or not.

I also added a check in the `getEntityUrl()` for file types, they don't have a canonical link template but for now `url()` generates a good url.

# What's new?

* Added a setting form with a checkbox.

* Does this change require documentation to be updated? included
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
(ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? yes, toggling the checkbox could affect how items are serialized out to Fedora/Milliner/Triplestores/Solr.

# How should this be tested?

1. Pull down the PR
1. Create a Repository Item (say `http://localhost:8000/node/3`)
1. View the Json-ld ('http://localhost:8000/node/3?_format=jsonld`)
     * Note all the `@id`s have `?_format=jsonld` on the end
1. Goto http://localhost:8000/admin/config/search/jsonld
1. Check the checkbox and Save the configuration.
1. Reload the above Json-ld
    * Note the `@id`s no longer have ?_format=jsonld on the end.

# Interested parties
@Islandora-CLAW/committers
