### PR TITLE
Use language neutral URIs

### DIFF
--- a/jsonld.services.yml
+++ b/jsonld.services.yml
@@ -17,10 +17,10 @@ services:
     class: Drupal\jsonld\Normalizer\FileEntityNormalizer
     tags:
       - { name: normalizer, priority: 20 }
-    arguments: ['@entity_type.manager', '@http_client', '@hal.link_manager', '@module_handler', '@file_system', '@config.factory']
+    arguments: ['@entity_type.manager', '@http_client', '@hal.link_manager', '@module_handler', '@file_system', '@config.factory', '@language_manager', '@router.route_provider']
   serializer.normalizer.entity.jsonld:
     class: Drupal\jsonld\Normalizer\ContentEntityNormalizer
-    arguments: ['@hal.link_manager', '@entity_type.manager', '@module_handler', '@config.factory']
+    arguments: ['@hal.link_manager', '@entity_type.manager', '@module_handler', '@config.factory', '@language_manager', '@router.route_provider']
     tags:
       - { name: normalizer, priority: 10 }
   serializer.encoder.jsonld:

--- a/src/Normalizer/FileEntityNormalizer.php
+++ b/src/Normalizer/FileEntityNormalizer.php
@@ -6,6 +6,8 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Routing\RouteProviderInterface;
 use Drupal\hal\LinkManager\LinkManagerInterface;
 use GuzzleHttp\ClientInterface;
 
@@ -50,15 +52,21 @@ class FileEntityNormalizer extends ContentEntityNormalizer {
    *   The file system handler.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The configuration factory.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   * @param \Drupal\Core\Routing\RouteProviderInterface $route_provider
+   *   The route provider.
    */
   public function __construct(EntityTypeManagerInterface $entity_manager,
                               ClientInterface $http_client,
                               LinkManagerInterface $link_manager,
                               ModuleHandlerInterface $module_handler,
                               FileSystemInterface $file_system,
-                              ConfigFactoryInterface $config_factory) {
+                              ConfigFactoryInterface $config_factory,
+                              LanguageManagerInterface $language_manager,
+                              RouteProviderInterface $route_provider) {
 
-    parent::__construct($link_manager, $entity_manager, $module_handler, $config_factory);
+    parent::__construct($link_manager, $entity_manager, $module_handler, $config_factory, $language_manager, $route_provider);
 
     $this->httpClient = $http_client;
     $this->fileSystem = $file_system;


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1133

# What does this Pull Request do?

Attempts to use language neutral URIs in JSON-LD serializations for `@id`s as all language triples are returned in the same graph.

Looks for a REST endpoint to GET the uri from, if this doesn't exist it falls back to the old non-language neutral method.

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
(ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

1. In a new Islandora 8, add a second language.
1. Create a new Repository Item, and select the second language in the **Language** field.
1. Save the object.
1. Look in Fedora and see that no fields made it to Fedora.
1. Pull in this PR.
1. Clear caches
1. Edit your resource and you should now see the content in Fedora.

# Interested parties
@dannylamb @Natkeeran or any available @Islandora-CLAW/committers
